### PR TITLE
BugFix: interp_x86 'neg_a' case missing

### DIFF
--- a/interp_x86/eval_x86.py
+++ b/interp_x86/eval_x86.py
@@ -162,6 +162,8 @@ class X86Emulator:
             return self.variables[str(a.children[0])]
         elif a.data == 'int_a':
             return self.eval_imm(a.children[0])
+        elif a.data == 'neg_a':
+            return -self.eval_imm(a.children[0])
         elif a.data == 'mem_a':
             offset, reg = a.children
             addr = self.registers[reg]


### PR DESCRIPTION
Interpreter was failing with negative immediate values. 

Test Program Lvar:
    x = (30 - 2)
    y = (x - 5)
    print((x - y))

Test Program x86 Ast after select instructions:
main:
    movq $28, %rax
    movq %rax, x
    movq $-5, %rax      ---- interpreter was failing at this point - arg was Tree('neg_a', [Tree('int_a', [5])])
    addq x, %rax
    movq %rax, y
    movq y, %rax
    negq %rax                          
    movq %rax, tmp_.0
    movq x, %rax
    addq tmp_.0, %rax
    movq %rax, tmp_.1
    movq tmp_.1, %rdi
    callq print_int