### PR TITLE
Added limit_functions pass to 'compile' function in utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1467,6 +1467,12 @@ def compile(compiler, compiler_name, type_check_L, type_check_C,
         program = compiler.convert_assignments(program)
         trace_ast_and_concrete(program)
 
+    if hasattr(compiler, 'limit_functions'):
+        trace('\n# limit functions\n')
+        type_check_L(program)
+        program = compiler.limit_functions(program)
+        trace_ast_and_concrete(program)
+
     if hasattr(compiler, 'convert_to_closures'):
         trace('\n# closure conversion\n')
         type_check_L(program)


### PR DESCRIPTION
This pull request is in response to a post in our Slack.

> Something I noticed - the reference compiler for the many-args test does not appear to assign the sixth argument to a tuple (containing the remaining arguments).  This is especially noted in the select instructions step, where it appears to access variables g and h out of nothing… is there something I’m missing, or is this an issue with the autograder and/or solution?

Seems that the `compile` function in `utils.py`, which is called from each `*-server.py` file, did not mention the `limit_functions` pass. I have added it.