### PR TITLE
support Return None and fall-off

### DIFF
--- a/type_check_Lfun.py
+++ b/type_check_Lfun.py
@@ -81,6 +81,8 @@ class TypeCheckLfun(TypeCheckLarray):
           case _:
             raise Exception('type_check_exp: in call, unexpected ' + \
                             repr(func_t))
+      case Constant(None):
+        return VoidType()
       case _:
         return super().type_check_exp(e, env)
 

--- a/type_check_Lgrad.py
+++ b/type_check_Lgrad.py
@@ -58,6 +58,8 @@ class TypeCheckLgrad(TypeCheckLlambda):
     match e:
       case Constant(value) if value is True or value is False:
         return BoolType()
+      case Constant(None):
+        return VoidType()
       # Cases for Lvar
       case Name(id):
         return env[id]


### PR DESCRIPTION
Support explicit `Return None` or "falling off the end" with the same effect.

This PR should be coordinated with a related one in python-compiler.