### PR TITLE
Improvements to type-checking

### DIFF
--- a/interp_Lint.py
+++ b/interp_Lint.py
@@ -24,12 +24,16 @@ def interp_stmt(s):
             print(interp_exp(arg))
         case Expr(value):
             interp_exp(value)
+        case _:
+            raise Exception('error in interp_stmt, unexpected ' + repr(s))
 
 def interp(p):
     match p:
         case Module(body):
             for s in body:
                 interp_stmt(s)
+        case _:
+            raise Exception('error in interp, unexpected ' + repr(p))
 
 # This version is for InterpLvar to inherit from 
 class InterpLint:
@@ -77,6 +81,8 @@ class InterpLint:
     match p:
       case Module(body):
         self.interp_stmts(body, {})
+      case _:
+        raise Exception('error in interp, unexpected ' + repr(p))
     
 if __name__ == "__main__":
   eight = Constant(8)

--- a/type_check_Ctup.py
+++ b/type_check_Ctup.py
@@ -57,7 +57,7 @@ class TypeCheckCtup(TypeCheckCwhile):
       case Collect(size):
         pass
       case Assign([Subscript(tup, Constant(index), Store())], value):
-        tup_t = self.type_check_atm(tup, env)
+        tup_t = self.type_check_exp(tup, env)
         value_t = self.type_check_atm(value, env)
         match tup_t:
           case TupleType(ts):

--- a/type_check_Lfun.py
+++ b/type_check_Lfun.py
@@ -99,7 +99,10 @@ class TypeCheckLfun(TypeCheckLarray):
         else:
             new_params = params
             new_returns = returns
-        for (x,t) in new_params:
+        unique_names = {x for x,_ in new_params}             
+        if len(unique_names) != len(new_params):
+            raise Exception('type_check: duplicate parameter name in function ' + repr(name))
+        for x,t in new_params:
             new_env[x] = t
         rt = self.type_check_stmts(body, new_env)
         self.check_type_equal(new_returns, rt, ss[0])
@@ -121,6 +124,8 @@ class TypeCheckLfun(TypeCheckLarray):
                                 for p in params.args]
                 else:
                     params_t = [t for (x,t) in params]
+                if name in env:
+                    raise Exception('type_check: duplicate function name ' + name)
                 env[name] = FunctionType(params_t, self.parse_type_annot(returns))
         self.type_check_stmts(body, env)
       case _:

--- a/type_check_Llambda.py
+++ b/type_check_Llambda.py
@@ -19,7 +19,7 @@ class TypeCheckLlambda(TypeCheckLfun):
       case Closure(arity, es):
         ts = [self.type_check_exp(e, env) for e in es]
         e.has_type = TupleType(ts)
-        return e.has_type
+        return e.has_type  # this is just wrong: closure values with different shapes must be given compatible types
       case Lambda(params, body):
         raise Exception('cannot synthesize a type for lambda: ' + str(e))
       case AllocateClosure(length, typ, arity):

--- a/type_check_Ltup.py
+++ b/type_check_Ltup.py
@@ -9,7 +9,7 @@ class TypeCheckLtup(TypeCheckLwhile):
     match t1:
       case TupleType(ts1):
         match t2:
-          case TupleType(ts2):
+          case TupleType(ts2):  # if len(ts1) == len(ts2):  -- including this breaks Llambda type checking because of bogus treatment of closure types there
             for (ty1, ty2) in zip(ts1,ts2):
               self.check_type_equal(ty1, ty2, e)
           case _:
@@ -51,6 +51,12 @@ class TypeCheckLtup(TypeCheckLwhile):
       case GlobalValue(name):
         return IntType()
       case Allocate(length, typ):
+        match typ:
+          case TupleType(_):
+            e.has_type = typ
+            return typ
+          case _:
+            raise Exception('type_check_exp: Allocate expected a tuple, not ' + repr(typ))
         return typ
       case _:
         return super().type_check_exp(e, env)


### PR DESCRIPTION
Some improvements to type-checking, especially to enforce proper tails in C languages.

Note that one improvement, in type_check_Ltuple.py, cannot be implemented until an issue with closure typing is fixed.

This PR should be coordinated with a related one in python-compiler.