### PR TITLE
improve x86 emulation so it can handle final programs up through lambda

### DIFF
--- a/interp_x86/convert_x86.py
+++ b/interp_x86/convert_x86.py
@@ -27,7 +27,7 @@ def convert_arg(arg):
             return Tree('mem_a', [convert_int(offset), reg])
         case ByteReg(id):
             return Tree('reg_a', [id])
-        case GlobalValue(id):
+        case Global(id):
             return Tree('global_val_a', [id, 'rip'])
         case _:
             raise Exception('convert_arg: unhandled ' + repr(arg))
@@ -38,10 +38,14 @@ def convert_instr(instr):
             return Tree(instr, [convert_arg(arg) for arg in args])
         case Callq(func, args):
             return Tree('callq', [func])
+        case IndirectCallq(func, args):
+            return Tree('indirect_callq', [convert_arg(func)])
         case Jump(label):
             return Tree('jmp', [label])
         case JumpIf(cc, label):
             return Tree('j' + cc, [label])
+        case IndirectJump(func):
+            return Tree('indirect_jmp', [convert_arg(func)])
         case _:
             raise Exception('error in convert_instr, unhandled ' + repr(instr))
 

--- a/utils.py
+++ b/utils.py
@@ -1075,6 +1075,18 @@ def mul64(x,y):
 def neg64(x):
     return to_signed(-x)
 
+def shiftra64(x,y):
+    return to_signed(x>>y)
+
+def shiftl64(x,y):
+    return to_signed(x<<y)
+
+def and64(x,y):
+    return to_signed(x&y)
+
+def or64(x,y):
+    return to_signed(x|y)
+
 def xor64(x,y):
     return to_signed(x^y)
 


### PR DESCRIPTION
A few fixes and improvements:

- With appropriate flag setting, emulator checks that callee-save registers are not disturbed by calls and garbages caller-save registers.  This allows easier debugging.
- Add additional support to allow emulation of unified final programs (although still not lists of FunctionDefs) up through lambdas.  The remaining chapters still require additional primitive functions.