### PR TITLE
utils.py testing framework improvements

### DIFF
--- a/run-some-tests.py
+++ b/run-some-tests.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import os
+import sys
+import getopt
+
+from utils import run_selected_tests, enable_tracing, enable_emulation
+
+import var
+
+sys.setrecursionlimit(10000)
+
+try:
+    opts, files = getopt.getopt(sys.argv[1:],"te")
+except getopt.GetoptError:
+    print ('usage: run-tests.py [-t] [-e]')
+    sys.exit(1)
+
+for opt,arg  in opts:
+    if opt == '-t':
+        enable_tracing()
+    if opt == '-e':
+        enable_emulation()
+        
+run_selected_tests(files,
+                   var.Var(), 'var',
+                   var.type_check_dict, var.interp_dict) 
+

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,7 @@ from sys import platform
 import ast
 from ast import *
 from dataclasses import dataclass
+from contextlib import redirect_stdout,_RedirectStream
 
 # move these to the compilers, use a method with overrides -Jeremy
 builtin_functions = \
@@ -1120,16 +1121,28 @@ def label_name(n: str) -> str:
 
 tracing = False
 
+emulate_x86 = False
 
 def enable_tracing():
     global tracing
     tracing = True
+
+def enable_emulation():
+    global emulate_x86
+    emulate_x86 = True
 
 
 def trace(msg):
     if tracing:
         print(msg, file=sys.stderr)
 
+
+def trace_ast_and_concrete(ast):
+    trace("concrete syntax:")
+    trace(ast)
+    trace("")
+    trace("AST:")
+    trace(repr(ast))
 
 def is_python_extension(filename):
     s = os.path.splitext(filename)
@@ -1138,6 +1151,8 @@ def is_python_extension(filename):
     else:
         return False
 
+class redirect_stdin(_RedirectStream):
+    _stream = "stdin"
 
 # Given the `ast` output of a pass and a test program (root) name,
 # runs the interpreter on the program and compares the output to the
@@ -1146,14 +1161,12 @@ def test_pass(passname, interp_dict, program_root, ast,
               compiler_name):
     if passname in interp_dict.keys():
         input_file = program_root + '.in'
+        if not os.path.isfile(input_file):
+            input_file = "/dev/null"
         output_file = program_root + '.out'
-        stdin = sys.stdin
-        stdout = sys.stdout
-        sys.stdin = open(input_file, 'r')
-        sys.stdout = open(output_file, 'w')
-        interp_dict[passname](ast)
-        sys.stdin = stdin
-        sys.stdout = stdout
+        with open(input_file, 'r') as inf, open(output_file, 'w') as outf:
+            with redirect_stdout(outf), redirect_stdin(inf):
+                interp_dict[passname](ast)
         result = os.system('diff' + ' -b ' + output_file + ' ' + program_root + '.golden')
         if result == 0:
             trace('compiler ' + compiler_name + ' success on pass ' + passname \
@@ -1411,23 +1424,25 @@ def compile_and_test(compiler, compiler_name,
     total_passes += 1
 
     # Run the final x86 program
-    emulate_x86 = False
+    input_file = program_root + '.in'
+    if not os.path.isfile(input_file):
+        input_file = "/dev/null"
+    output_file = program_root + '.out'
     if emulate_x86:
-        stdin = sys.stdin
-        stdout = sys.stdout
-        sys.stdin = open(program_root + '.in', 'r')
-        sys.stdout = open(program_root + '.out', 'w')
-        interp_x86(program)
-        sys.stdin = stdin
-        sys.stdout = stdout
+         trace('emulating x86')
+         with open(input_file, 'r') as inf, open(output_file, 'w') as outf:
+              with redirect_stdout(outf), redirect_stdin(inf):
+                  interp_x86(program)
     else:
-        if platform == 'darwin':
-            os.system('gcc -arch x86_64 runtime.o ' + x86_filename)
-        else:
-            os.system('gcc runtime.o ' + x86_filename)
-        input_file = program_root + '.in'
-        output_file = program_root + '.out'
-        os.system('./a.out < ' + input_file + ' > ' + output_file)
+        trace('executing x86')
+        arch = ' -arch x86_64' if platform == 'darwin' else ''
+        x86_executable = program_root + '.exe'
+        if os.path.isfile(x86_executable):
+            os.remove(x86_executable)
+        if os.path.isfile(output_file):
+            os.remove(output_file)
+        os.system('gcc' + arch + ' -o ' + x86_executable + ' runtime.o ' + x86_filename)
+        os.system(x86_executable + ' < ' + input_file + ' > ' + output_file)
 
     result = os.system('diff' + ' -b ' + program_root + '.out ' \
                        + program_root + '.golden')
@@ -1438,14 +1453,6 @@ def compile_and_test(compiler, compiler_name,
         print('compiler ' + compiler_name + ', executable failed' \
               + ' on test ' + program_root)
         return (successful_passes, total_passes, 0)
-
-
-def trace_ast_and_concrete(ast):
-    trace("concrete syntax:")
-    trace(ast)
-    trace("")
-    trace("AST:")
-    trace(repr(ast))
 
 
 # This function compiles the program without any testing
@@ -1539,18 +1546,20 @@ def compile(compiler, compiler_name, type_check_L, type_check_C,
 # C intermediate language, run all the passes in the compiler,
 # checking that the resulting programs produce output that matches the
 # golden file.
-def run_one_test(test, lang, compiler, compiler_name,
+def run_one_test(test, compiler, compiler_name,
                  type_check_dict, interp_dict):
-#    test_root = os.path.splitext(test)[0]
-#    test_name = os.path.basename(test_root)
-    return compile_and_test(compiler, compiler_name, type_check_dict,
-                            interp_dict, test)
+    try: 
+        return compile_and_test(compiler, compiler_name,
+                                type_check_dict, interp_dict, test) 
+    except Exception as exn:
+        from traceback import print_exc
+        print_exc(file=sys.stderr)
+        return (0,0,0)
 
-
-# Given the name of a language, a compiler, the compiler's name, a
-# type checker and interpreter for the language, and an interpreter
-# for the C intermediate language, test the compiler on all the tests
-# in the directory of for the given language, i.e., all the
+# Given the name of a language, a compiler, the compiler's name, and
+# dictionaries of type checkers and interpreters for the language
+# and its intermediate forms, test the compiler on all the tests 
+# in the directory for the given language, i.e., all the
 # python files in ./tests/<language>.
 def run_tests(lang, compiler, compiler_name, type_check_dict, interp_dict):
     # Collect all the test programs for this language.
@@ -1570,8 +1579,8 @@ def run_tests(lang, compiler, compiler_name, type_check_dict, interp_dict):
     total_tests = 0
     for test in tests:
         (succ_passes, tot_passes, succ_test) = \
-            run_one_test(test, lang, compiler, compiler_name,
-                         type_check_dict, interp_dict)
+            run_one_test(test, compiler, compiler_name,
+                         type_check_dict, interp_dict) 
         successful_passes += succ_passes
         total_passes += tot_passes
         successful_tests += succ_test
@@ -1582,3 +1591,31 @@ def run_tests(lang, compiler, compiler_name, type_check_dict, interp_dict):
           + ' for compiler ' + compiler_name + ' on language ' + lang)
     print('passes: ' + repr(successful_passes) + '/' + repr(total_passes) \
           + ' for compiler ' + compiler_name + ' on language ' + lang)
+
+# Given a list of file names, a compiler, the compiler's name, and
+# dictionaries of type checkers and interpreters for the language
+# and its intermediate forms, test the compiler on all the tests 
+# in the directory for the given language, i.e., all the
+# python files in ./tests/<language>.
+def run_selected_tests(tests, compiler, compiler_name,
+                       type_check_dict, interp_dict):
+    # Compile and run each test program, comparing output to the golden file.
+    successful_passes = 0
+    total_passes = 0
+    successful_tests = 0
+    total_tests = 0
+    for test in tests:
+        print(test + ':', file=sys.stderr)
+        (succ_passes, tot_passes, succ_test) = \
+            run_one_test(test, compiler, compiler_name) 
+        successful_passes += succ_passes
+        total_passes += tot_passes
+        successful_tests += succ_test
+        total_tests += 1
+
+    # Report the pass/fails
+    print('tests: ' + repr(successful_tests) + '/' + repr(total_tests) \
+          + ' for compiler ' + compiler_name)
+    print('passes: ' + repr(successful_passes) + '/' + repr(total_passes) \
+          + ' for compiler ' + compiler_name)
+    

--- a/utils.py
+++ b/utils.py
@@ -289,7 +289,7 @@ Not.__repr__ = repr_Not
 
 
 def str_UnaryOp(self):
-    return str(self.op) + ' ' + str(self.operand)
+    return str(self.op) + '(' + str(self.operand) + ')'
 
 
 UnaryOp.__str__ = str_UnaryOp
@@ -766,9 +766,9 @@ class Begin(expr):
     def __str__(self):
         indent()
         stmts = ''.join([str(s) for s in self.body])
-        end = indent_stmt() + str(self.result)
+        end = indent_stmt() + + 'produce ' + str(self.result)
         dedent()
-        return 'begin:\n' + stmts + end
+        return '{\n' + stmts + end + '}'
 
 
 @dataclass


### PR DESCRIPTION
A set of changes to tidy up the testing framework and add new functionality:

In utils.py:
- flag for emulation of final x86 program is exposed in a new function
- exceptions are caught and printed before continuing, allowing easier testing of large suites.
- no .in file is needed for tests that don't do input
- executable files are saved with .exe extension rather than defaulting to a.out

There is a new file run-some-tests.py that allows a set of tests to be specified on the command line using standard shell expansion, and provides flags for setting tracing and/or emulation.