### PR TITLE
fixed testing bug for prelude_and_conclusion

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1200,6 +1200,18 @@ def compile_and_test(compiler, compiler_name,
         trace('\n# type checking source program\n')
         type_check_dict['source'](program)
 
+    passname = 'part_eval'
+    if hasattr(compiler, passname):
+        trace('\n# ' + passname + '\n')
+        program = compiler.part_eval(program)
+        trace(program)
+        trace('')
+        if passname in type_check_dict.keys():
+            type_check_dict[passname](program)
+        total_passes += 1
+        successful_passes += \
+            test_pass(passname, interp_dict, program_root, program,
+                      compiler_name)
     passname = 'shrink'
     if hasattr(compiler, passname):
         trace('\n# ' + passname + '\n')
@@ -1212,6 +1224,9 @@ def compile_and_test(compiler, compiler_name,
         successful_passes += \
             test_pass(passname, interp_dict, program_root, program,
                       compiler_name)
+        
+    
+
         
     passname = 'uniquify'
     if hasattr(compiler, passname):
@@ -1430,7 +1445,6 @@ def compile_and_test(compiler, compiler_name,
             dest.write(str(program))
 
         total_passes += 1
-
         # Run the final x86 program
         emulate_x86 = False
         if emulate_x86:
@@ -1439,6 +1453,7 @@ def compile_and_test(compiler, compiler_name,
             sys.stdin = open(program_root + '.in', 'r')
             sys.stdout = open(program_root + '.out', 'w')
             interp_x86(program)
+            print() # print a newline to make diff happy
             sys.stdin = stdin
             sys.stdout = stdout
         else:
@@ -1449,7 +1464,10 @@ def compile_and_test(compiler, compiler_name,
             input_file = program_root + '.in'
             output_file = program_root + '.out'
             os.system('./a.out < ' + input_file + ' > ' + output_file)
-
+            # print a newline to make diff happy
+            with open(output_file, 'a') as file:
+                # Write newline
+                file.write("\n")
         result = os.system('diff' + ' -b ' + program_root + '.out ' \
                            + program_root + '.golden')
         if result == 0:

--- a/utils.py
+++ b/utils.py
@@ -1199,19 +1199,6 @@ def compile_and_test(compiler, compiler_name,
     if 'source' in type_check_dict.keys():
         trace('\n# type checking source program\n')
         type_check_dict['source'](program)
-
-    passname = 'part_eval'
-    if hasattr(compiler, passname):
-        trace('\n# ' + passname + '\n')
-        program = compiler.part_eval(program)
-        trace(program)
-        trace('')
-        if passname in type_check_dict.keys():
-            type_check_dict[passname](program)
-        total_passes += 1
-        successful_passes += \
-            test_pass(passname, interp_dict, program_root, program,
-                      compiler_name)
     passname = 'shrink'
     if hasattr(compiler, passname):
         trace('\n# ' + passname + '\n')
@@ -1223,11 +1210,7 @@ def compile_and_test(compiler, compiler_name,
         total_passes += 1
         successful_passes += \
             test_pass(passname, interp_dict, program_root, program,
-                      compiler_name)
-        
-    
-
-        
+                      compiler_name)    
     passname = 'uniquify'
     if hasattr(compiler, passname):
         trace('\n# ' + passname + '\n')


### PR DESCRIPTION
a new line is printed at the end of the output file for compatibility with diff in all the other passes except for prelude and conclusion causing certain tests to fail incorrectly. This addresses that