### PR TITLE
Bug in interp_Lwhile.py: missing return in interpreter definition.

### DIFF
--- a/interp_Lwhile.py
+++ b/interp_Lwhile.py
@@ -8,7 +8,7 @@ class InterpLwhile(InterpLif):
     match s:
       case While(test, body, []):
         if self.interp_exp(test, env):
-            self.interp_stmts(body + [s] + cont, env)
+          return self.interp_stmts(body + [s] + cont, env)
         else:
           return self.interp_stmts(cont, env)
       case _:


### PR DESCRIPTION
Missing 'return' for the body case. 

Without this 'return' the following code prints 'None' instead of '9':

```
def func(a: int) -> int:
    i = True

    while i:
       a = a - 1
       i = False

    # print(a) at this point will print 9
    return a

print(func(10)) # expected 9, got None
```